### PR TITLE
port to python 3.8

### DIFF
--- a/source/python/cni/dlogen.py
+++ b/source/python/cni/dlogen.py
@@ -16,6 +16,8 @@
 #
 ########################################################################
 
+from typing import List
+
 from cni.rect import *
 from cni.grouping import *
 from cni.pin import *
@@ -177,7 +179,7 @@ class DloGen(Dlo):
             raise Exception("Library name not set!")
         return cls._libName
 
-    def getShapes(self) -> list[Shape]:
+    def getShapes(self) -> List[Shape]:
         cellContext = self._getCurrentCellContext()
         shapes = []
         [shapes.append(shape) for shape in cellContext.shapes]

--- a/source/python/cni/instance.py
+++ b/source/python/cni/instance.py
@@ -105,25 +105,24 @@ class Instance():
         :type orientation: Orientation
 
         """
-        match orientation:
-            case Orientation.R0:
-                transform = pya.DTrans(0, False)
-            case Orientation.R90:
-                transform = pya.DTrans(90, False)
-            case Orientation.R180:
-                transform = pya.DTrans(180, False)
-            case Orientation.R270:
-                transform = pya.DTrans(270, False)
-            case Orientation.MYR90:
-                transform = pya.DTrans(90, False) * pya.DTrans.M90
-            case Orientation.MXR90:
-                transform = pya.DTrans(90, True)
-            case Orientation.MY:
-                transform = pya.DTrans(0, False) * pya.DTrans.M90
-            case Orientation.MX:
-                transform = pya.DTrans(0, True)
-            case _:
-                raise Exception(f"Unknown orientation '{orientation}'")
+        if orientation == Orientation.R0:
+            transform = pya.DTrans(0, False)
+        elif orientation == Orientation.R90:
+            transform = pya.DTrans(90, False)
+        elif orientation == Orientation.R180:
+            transform = pya.DTrans(180, False)
+        elif orientation == Orientation.R270:
+            transform = pya.DTrans(270, False)
+        elif orientation == Orientation.MYR90:
+            transform = pya.DTrans(90, False) * pya.DTrans.M90
+        elif orientation == Orientation.MXR90:
+            transform = pya.DTrans(90, True)
+        elif orientation == Orientation.MY:
+            transform = pya.DTrans(0, False) * pya.DTrans.M90
+        elif orientation == Orientation.MX:
+            transform = pya.DTrans(0, True)
+        else:
+            raise Exception(f"Unknown orientation '{orientation}'")
 
         Shape.getCell().transform(self._instance, transform)
 

--- a/source/python/cni/text.py
+++ b/source/python/cni/text.py
@@ -68,34 +68,33 @@ class Text(Shape):
     def setAlignment(self, location: Location) -> None:
         width = len(self._text.string) * self._height
 
-        match location:
-            case Location.LOWER_LEFT:
-                self._text.halign = pya.HAlign.HAlignLeft
-                self._text.valign = pya.VAlign.VAlignBottom
-            case Location.CENTER_LEFT:
-                self._text.halign = pya.HAlign.HAlignLeft
-                self._text.valign = pya.VAlign.VAlignCenter
-            case Location.UPPER_LEFT:
-                self._text.halign = pya.HAlign.HAlignLeft
-                self._text.valign = pya.VAlign.VAlignTop
-            case Location.LOWER_CENTER:
-                self._text.halign = pya.HAlign.HAlignCenter
-                self._text.valign = pya.VAlign.VAlignBottom
-            case Location.CENTER_CENTER:
-                self._text.halign = pya.HAlign.HAlignCenter
-                self._text.valign = pya.VAlign.VAlignCenter
-            case Location.UPPER_CENTER:
-                self._text.halign = pya.HAlign.HAlignCenter
-                self._text.valign = pya.VAlign.VAlignTop
-            case Location.LOWER_RIGHT:
-                self._text.halign = pya.HAlign.HAlignRight
-                self._text.valign = pya.VAlign.VAlignBottom
-            case Location.CENTER_RIGHT:
-                self._text.halign = pya.HAlign.HAlignRight
-                self._text.valign = pya.VAlign.VAlignCenter
-            case Location.UPPER_RIGHT:
-                self._text.halign = pya.HAlign.HAlignRight
-                self._text.valign = pya.VAlign.VAlignTop
+        if location == Location.LOWER_LEFT:
+            self._text.halign = pya.HAlign.HAlignLeft
+            self._text.valign = pya.VAlign.VAlignBottom
+        elif location == Location.CENTER_LEFT:
+            self._text.halign = pya.HAlign.HAlignLeft
+            self._text.valign = pya.VAlign.VAlignCenter
+        elif location == Location.UPPER_LEFT:
+            self._text.halign = pya.HAlign.HAlignLeft
+            self._text.valign = pya.VAlign.VAlignTop
+        elif location == Location.LOWER_CENTER:
+            self._text.halign = pya.HAlign.HAlignCenter
+            self._text.valign = pya.VAlign.VAlignBottom
+        elif location == Location.CENTER_CENTER:
+            self._text.halign = pya.HAlign.HAlignCenter
+            self._text.valign = pya.VAlign.VAlignCenter
+        elif location == Location.UPPER_CENTER:
+            self._text.halign = pya.HAlign.HAlignCenter
+            self._text.valign = pya.VAlign.VAlignTop
+        elif location == Location.LOWER_RIGHT:
+            self._text.halign = pya.HAlign.HAlignRight
+            self._text.valign = pya.VAlign.VAlignBottom
+        elif location == Location.CENTER_RIGHT:
+            self._text.halign = pya.HAlign.HAlignRight
+            self._text.valign = pya.VAlign.VAlignCenter
+        elif location == Location.UPPER_RIGHT:
+            self._text.halign = pya.HAlign.HAlignRight
+            self._text.valign = pya.VAlign.VAlignTop
 
         layer = self.getShape().layer
 

--- a/source/python/cni/transform.py
+++ b/source/python/cni/transform.py
@@ -77,25 +77,24 @@ class Transform(object):
         self._orientation = orientation
         self._mag = magnification
 
-        match orientation:
-            case Orientation.R0:
-                self._transform = pya.DCplxTrans(magnification, 0, False, x, y)
-            case Orientation.R90:
-                self._transform = pya.DCplxTrans(magnification, 90, False, x, y)
-            case Orientation.R180:
-                self._transform = pya.DCplxTrans(magnification, 180, False, x, y)
-            case Orientation.R270:
-                self._transform = pya.DCplxTrans(magnification, 270, False, x, y)
-            case Orientation.MYR90:
-                self._transform = pya.DCplxTrans(magnification, 90, False, x, y) * pya.DCplxTrans.M90
-            case Orientation.MXR90:
-                self._transform = pya.DCplxTrans(magnification, 90, True, x, y)
-            case Orientation.MY:
-                self._transform = pya.DCplxTrans(magnification, 0, False, x, y) * pya.DCplxTrans.M90
-            case Orientation.MX:
-                self._transform = pya.DCplxTrans(magnification, 0, True, x, y)
-            case _:
-                raise Exception(f"Unknown orientation '{orientation}'")
+        if orientation == Orientation.R0:
+            self._transform = pya.DCplxTrans(magnification, 0, False, x, y)
+        elif orientation == Orientation.R90:
+            self._transform = pya.DCplxTrans(magnification, 90, False, x, y)
+        elif orientation == Orientation.R180:
+            self._transform = pya.DCplxTrans(magnification, 180, False, x, y)
+        elif orientation == Orientation.R270:
+            self._transform = pya.DCplxTrans(magnification, 270, False, x, y)
+        elif orientation == Orientation.MYR90:
+            self._transform = pya.DCplxTrans(magnification, 90, False, x, y) * pya.DCplxTrans.M90
+        elif orientation == Orientation.MXR90:
+            self._transform = pya.DCplxTrans(magnification, 90, True, x, y)
+        elif orientation == Orientation.MY:
+            self._transform = pya.DCplxTrans(magnification, 0, False, x, y) * pya.DCplxTrans.M90
+        elif orientation == Orientation.MX:
+            self._transform = pya.DCplxTrans(magnification, 0, True, x, y)
+        else:
+            raise Exception(f"Unknown orientation '{orientation}'")
 
     @property
     def transform(self):

--- a/source/python/cni/ulist.py
+++ b/source/python/cni/ulist.py
@@ -16,11 +16,12 @@
 #
 ########################################################################
 
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, List
+
 
 T = TypeVar('T')
 
-class ulist(list[T]):
+class ulist(List[T]):
 
     def __init__(self, items = None) -> None:
         if items is not None:


### PR DESCRIPTION
This PR ports the Klayout pycells API to be compatible with Python 3.8.
I have built KLayout 0.30.0 by myself (not pre-built packages -> Those contain default Python 3.6).

Two types of changes are included:
- Replace `match`  by `if-else-if`
- Remove implicit use of `list`, replace by `Typing.List`

Tested on RHEL8 with latest python available for this RHEL version.

After including the latest changes from [4c463c4](https://github.com/IHP-GmbH/pycell4klayout-api/commit/4c463c43991fb0967a824906518b66047bfb33c4), I am able to create each of 
the provided cells without Klayout throwing any error.