### PR TITLE
Shape.bbox fixes for Polygon, Path

### DIFF
--- a/source/python/cni/polygon.py
+++ b/source/python/cni/polygon.py
@@ -88,6 +88,7 @@ class Polygon(Shape):
         shape = Shape.getCell().shapes(self.getShape().layer).insert(transformedPolygon)
         self.destroy()
         self._polygon = transformedPolygon
+        self._bbox = transformedPolygon.bbox()
         self.set_shape(shape)
         self.addShape()
 

--- a/source/python/cni/shape.py
+++ b/source/python/cni/shape.py
@@ -35,7 +35,13 @@ class Shape(PhysicalComponent):
     def __init__(self, layer: Layer, bbox: Box):
         self._shape = None  # pya.Shape
         self._layer = layer
-        self._bbox = bbox
+
+        if isinstance(bbox, Box):
+            self._bbox = bbox
+        elif isinstance(bbox, pya.DBox):
+            self._bbox = Box(bbox.left, bbox.bottom, bbox.right, bbox.top)
+        else:
+            raise NotImplementedError()
         self._net = None
         self._pin = None
 


### PR DESCRIPTION
We're working on a guard ring feature, so
within a `DloGen`, I've wanted to use the `Shape.bbox` property on all shapes:
```python
             for s in self.getShapes():
                if isinstance(s, cni.text.Text):
                    continue

                print(f"{self.__class__.__name__} shape type is {type(s)}, "
                      f"type(s.bbox)={type(s.bbox)}")   # THIS would be bool for Polygon, Path!!!

                bbox = s.getBBox()
                if isinstance(bbox, bool):
                    # FIXME: in dpantenna/inductor2/inductor3 cells,
                    #        strangely Polygon shapes
                    #        had s.bbox being a boolean!
                    #        skip those for now
                    print(f"Shape details: {s.__dict__}")
                    pass #continue
                min_left = min(min_left, bbox.left)
                min_bottom = min(min_bottom, bbox.bottom)
                max_right = max(max_right, bbox.right)
                max_top = max(max_top, bbox.top)
```

So the strange thing was, for regular 'cni.box.Box' shapes this would work,
but for `cni.polygon.Polygon` and `cni.path.Path` this would not work,
instead `s.bbox` would be a `bool`.

This seems to come from the fact, that `Shape._bbox` has to be of type `cni.box.Box`,
but `Polygon` and `Path` did assign `pya.DBox` to it.